### PR TITLE
Create Civo instance with dynamic size and disk img

### DIFF
--- a/terraform/modules/civo-instance/main.tf
+++ b/terraform/modules/civo-instance/main.tf
@@ -1,34 +1,5 @@
 resource "random_pet" "generated" {}
 
-# Query small instance size
-data "civo_size" "small" {
-  filter {
-    key      = "name"
-    values   = [var.instance_type]
-    match_by = "re"
-  }
-
-  filter {
-    key    = "type"
-    values = ["instance"]
-  }
-}
-
-# Query instance disk image
-data "civo_disk_image" "ubuntu" {
-  filter {
-    key    = "name"
-    values = [var.disk_image_name]
-  }
-
-  filter {
-    key    = "version"
-    values = [var.disk_image_version]
-  }
-
-  region = var.region
-}
-
 data "civo_ssh_key" "shared_ssh_key" {
   name = "rjindal"
 }
@@ -39,8 +10,8 @@ resource "civo_instance" "instances" {
   hostname     = "server-${random_pet.generated.id}-${count.index}"
   tags         = ["server", "cpu"]
   notes        = "host for running service"
-  size         = element(data.civo_size.small.sizes, 0).name
-  disk_image   = element(data.civo_disk_image.ubuntu.diskimages, 0).id
+  size         = var.instance_type
+  disk_image   = var.disk_image_name
   sshkey_id    = data.civo_ssh_key.shared_ssh_key.id
   initial_user = "ubuntu"
   region       = var.region


### PR DESCRIPTION
You can use the below syntax format to create the instance with dynamic size and disk image.
Here instead of querying we are directly acessing the element since there is only one element in the list.

You can also have a look at my terminal's output here: https://app.warp.dev/block/gUcCYPVyUIVlxwk4eQ9OXy